### PR TITLE
Fix for outdated method call in example app parserFeaturesInDirectory:featureTags:

### DIFF
--- a/CucumberishExample/CucumberishTest/CucumberishTest.m
+++ b/CucumberishExample/CucumberishTest/CucumberishTest.m
@@ -135,6 +135,6 @@ void CucumberishInit()
     //Optional step, see the comment on this property for more information
     [Cucumberish instance].fixMissingLastScenario = YES;
     //Tell Cucumberish the name of your features folder and let it execute them for you...
-    [[[Cucumberish instance] parserFeaturesInDirectory:@"Features" featureTags:nil] beginExecution];
+    [[[Cucumberish instance] parserFeaturesInDirectory:@"Features" includeTags:nil excludeTags:nil] beginExecution];
 }
 


### PR DESCRIPTION
I noticed that the example app was not using the recently introduced parseFeaturesInDirectory:includeTags:excludeTags method. 

Since this was a non-backwards compatible change, it broke the example app. This pull request fixes that based on the last few commits. 