### PR TITLE
Added explicit bundle parameter to the parser method

### DIFF
--- a/Cucumberish/Core/Managers/CCIFeaturesManager.h
+++ b/Cucumberish/Core/Managers/CCIFeaturesManager.h
@@ -54,7 +54,7 @@
  
  @Note tags in featureTags parameter should not exist in the execludedTags parameter as it doesn't make any sense.
  */
-- (void)parseFeatureFiles:(NSArray *)featureFiles withTags:(NSArray *)tags execludeFeaturesWithTags:(NSArray *)execludedFeatures;
+- (void)parseFeatureFiles:(NSArray *)featureFiles bundle:(NSBundle *)bundle withTags:(NSArray *)tags execludeFeaturesWithTags:(NSArray *)execludedFeatures;
 
 /**
  Associates the passed class with the passed feature instance for later usage.

--- a/Cucumberish/Core/Managers/CCIFeaturesManager.m
+++ b/Cucumberish/Core/Managers/CCIFeaturesManager.m
@@ -58,7 +58,8 @@
     self.featureClassMap = [@{} mutableCopy];
     return self;
 }
-- (void)parseFeatureFiles:(NSArray *)featureFiles withTags:(NSArray *)tags execludeFeaturesWithTags:(NSArray *)execludedFeatures
+
+- (void)parseFeatureFiles:(NSArray *)featureFiles bundle:(NSBundle *)bundle withTags:(NSArray *)tags execludeFeaturesWithTags:(NSArray *)execludedFeatures
 {
     NSMutableArray * parsedFeatures = [NSMutableArray array];
     
@@ -70,7 +71,7 @@
         if(result){
             NSMutableDictionary * featureData = [[result dictionary] mutableCopy];
             
-            NSString * testBundlePath = [[NSBundle bundleForClass:[self class]] bundlePath];
+            NSString * testBundlePath = [bundle bundlePath];
             NSString * localPath = [[[filePath.absoluteString stringByRemovingPercentEncoding]
                                      stringByReplacingOccurrencesOfString:testBundlePath withString:@""]
                                     stringByReplacingOccurrencesOfString:@"file://" withString:@""];

--- a/Cucumberish/Cucumberish.h
+++ b/Cucumberish/Cucumberish.h
@@ -71,42 +71,44 @@
  */
 + (instancetype)instance;
 
-
-
-
-
 /**
- Parses any .feature file that is located inside the passed folder name and map it to a test case if the feature inside the file has one or more tags of the passed tags (if any) and it doesn't have a tag from the execluded tags parameter
+ Parses any .feature file that is located inside the passed folder name and map it to a test case if the feature inside the file has one or more tags of the passed tags (if any) and it doesn't have a tag from the excluded tags parameter
  
- @Note The feature directory has to be a real physical folder. Also When adding this folder to your test target, and get the prompt on how you would like to add it from Xcode, choose "Create Folder Reference" and @b NOT to Create Groups.
+ @param directory a path to your featuresDirectory relative to your test target main folder.
+ @param bundle the bundle where the directory is located
+ @param includeTags array of strings to filter which features that will be parsed to be executed, if nil then all feature files will be parsed.
+ @param excludeTags array of string to filter which features should not be executed.
  
- @Note tags should not be prefixed with @@ symbole
- 
- @param featuresDirectory a path to your featuresDirectory relative to your test target main folder.
- @param tags array of strings to filter which features that will be parsed to be executed, if nil then all feature files will be parsed.
- 
- @param tags array of string to filter which features should not be executed.
- 
- @Note tags in includeTags parameter should not exist in the execludedTags parameter as it doesn't make any sense.
- @Note the tags will be also on the scenario level. That's it, if the feature passes the tag check, then we will check each of its scenarios against the tags as well. But if a feature is execluded (because it has a tag from the execludedTags array), none of its scenarios will be executed.
- 
- @return the singleton instance of Cucumberish so you can call beginExecution immediately if you want.
-
+ @note The feature directory has to be a real physical folder. Also When adding this folder to your test target, and get the prompt on how you would like to add it from Xcode, choose "Create Folder Reference" and @b NOT to Create Groups.
+ @note tags should not be prefixed with @@ symbole
+ @note tags in includeTags parameter should not exist in the excludedTags parameter as it doesn't make any sense.
+ @note the tags will be also on the scenario level. That's it, if the feature passes the tag check, then we will check each of its scenarios against the tags as well. But if a feature is excluded (because it has a tag from the excludedTags array), none of its scenarios will be executed.
  */
-- (Cucumberish *)parserFeaturesInDirectory:(NSString *)featuresDirectory includeTags:(NSArray<NSString *> *)tags excludeTags:(NSArray<NSString *> *)execludedTags;
+- (void)parserFeaturesInDirectory:(NSString *)directory
+                       fromBundle:(NSBundle *)bundle
+                      includeTags:(NSArray<NSString *> *)includeTags
+                      excludeTags:(NSArray<NSString *> *)excludeTags;
 
 /**
- Fire the executiion of all the previously parsed features in an alphabetic ascending order.
+ @deprecated This method is deprecated starting in version 0.9.1
+ @note Please use @code parserFeaturesInDirectory:fromBundle:includeTags:excludeTags @endcode instead.
+
+ @return the singleton instance of Cucumberish so you can call beginExecution immediately if you want.
+ */
+- (Cucumberish *)parserFeaturesInDirectory:(NSString *)featuresDirectory
+                               includeTags:(NSArray<NSString *> *)tags
+                               excludeTags:(NSArray<NSString *> *)excludedTags DEPRECATED_ATTRIBUTE;
+
+/**
+ Fire the execution of all the previously parsed features in an alphabetic ascending order.
  */
 - (void)beginExecution;
-
-
 
 /**
  Conventient method that calls parserFeaturesInDirectory:includeTags:excludeTags: followed by an immediate call to beginExecution
  
  */
-+ (void)executeFeaturesInDirectory:(NSString *)featuresDirectory includeTags:(NSArray<NSString *> *)tags excludeTags:(NSArray<NSString *> *)execludedTags;
++ (void)executeFeaturesInDirectory:(NSString *)featuresDirectory includeTags:(NSArray<NSString *> *)tags excludeTags:(NSArray<NSString *> *)excludedTags;
 @end
 
 

--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -81,17 +81,31 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
 }
 
 
-
-
-- (Cucumberish *)parserFeaturesInDirectory:(NSString *)featuresDirectory includeTags:(NSArray *)tags excludeTags:(NSArray *)execludedTags
+- (void)parserFeaturesInDirectory:(NSString *)directory fromBundle:(NSBundle *)bundle includeTags:(NSArray<NSString *> *)includeTags excludeTags:(NSArray<NSString *> *)excludeTags
 {
-    NSString * featuresPath = [[[NSBundle bundleForClass:[Cucumberish class]] resourcePath] stringByAppendingPathComponent:featuresDirectory];
-    
+    NSString * featuresPath = [[bundle resourcePath] stringByAppendingPathComponent:directory];
     NSArray * featureFiles = [[NSBundle bundleWithPath:featuresPath] URLsForResourcesWithExtension:@".feature" subdirectory:nil];
-    [[CCIFeaturesManager instance] parseFeatureFiles:featureFiles withTags:tags execludeFeaturesWithTags:execludedTags];
-    self.tags = tags;
-    self.excludedTags = execludedTags;
+
+    [[CCIFeaturesManager instance] parseFeatureFiles:featureFiles withTags:includeTags execludeFeaturesWithTags:excludeTags];
+    self.tags = includeTags;
+    self.excludedTags = excludeTags;
+}
+
+- (Cucumberish *)parserFeaturesInDirectory:(NSString *)featuresDirectory includeTags:(NSArray<NSString *> *)tags excludeTags:(NSArray<NSString *> *)excludedTags
+{
+    [self parserFeaturesInDirectory:featuresDirectory
+                         fromBundle:[NSBundle bundleForClass:[Cucumberish class]]
+                        includeTags:tags
+                        excludeTags:excludedTags];
     return self;
+}
+
++ (void)executeFeaturesInDirectory:(NSString *)featuresDirectory includeTags:(NSArray *)tags excludeTags:(NSArray *)excludedTags
+{
+    [[Cucumberish instance] parserFeaturesInDirectory:featuresDirectory
+                                           fromBundle:[NSBundle bundleForClass:[Cucumberish class]]
+                                          includeTags:tags
+                                          excludeTags:excludedTags];
 }
 
 - (void)beginExecution
@@ -105,13 +119,6 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
         [Cucumberish swizzleDefaultSuiteImplementationForClass:featureClass];
         [Cucumberish swizzleFailureRecordingImplementationForClass:featureClass];
     }
-}
-
-
-
-+ (void)executeFeaturesInDirectory:(NSString *)featuresDirectory includeTags:(NSArray *)tags excludeTags:(NSArray *)execludedTags
-{
-    [[[Cucumberish instance] parserFeaturesInDirectory:featuresDirectory includeTags:tags excludeTags:execludedTags] beginExecution];
 }
 
 #pragma mark - Manage hocks

--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -85,7 +85,7 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
 {
     NSArray * featureFiles = [bundle URLsForResourcesWithExtension:@".feature" subdirectory:directory];
 
-    [[CCIFeaturesManager instance] parseFeatureFiles:featureFiles withTags:includeTags execludeFeaturesWithTags:excludeTags];
+    [[CCIFeaturesManager instance] parseFeatureFiles:featureFiles bundle:bundle withTags:includeTags execludeFeaturesWithTags:excludeTags];
     self.tags = includeTags;
     self.excludedTags = excludeTags;
 }

--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -83,8 +83,7 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
 
 - (void)parserFeaturesInDirectory:(NSString *)directory fromBundle:(NSBundle *)bundle includeTags:(NSArray<NSString *> *)includeTags excludeTags:(NSArray<NSString *> *)excludeTags
 {
-    NSString * featuresPath = [[bundle resourcePath] stringByAppendingPathComponent:directory];
-    NSArray * featureFiles = [[NSBundle bundleWithPath:featuresPath] URLsForResourcesWithExtension:@".feature" subdirectory:nil];
+    NSArray * featureFiles = [bundle URLsForResourcesWithExtension:@".feature" subdirectory:directory];
 
     [[CCIFeaturesManager instance] parseFeatureFiles:featureFiles withTags:includeTags execludeFeaturesWithTags:excludeTags];
     self.tags = includeTags;

--- a/Cucumberish/Dependencies/Gherkin/GHGherkinDialectProvider.m
+++ b/Cucumberish/Dependencies/Gherkin/GHGherkinDialectProvider.m
@@ -52,7 +52,7 @@
 
 - (NSDictionary<NSString *, GHGherkinLanguageSetting *> *)languagesSetting
 {
-    NSBundle * gherkinLanguagesBundle = [NSBundle bundleWithPath: [[NSBundle mainBundle] pathForResource: @"GherkinLanguages" ofType: @"bundle"]];
+    NSBundle * gherkinLanguagesBundle = [NSBundle bundleWithPath: [[NSBundle bundleForClass:[self class]] pathForResource: @"GherkinLanguages" ofType: @"bundle"]];
     if(gherkinLanguagesBundle == nil){
         gherkinLanguagesBundle = [NSBundle bundleForClass:[self class]];
     }


### PR DESCRIPTION
On our project, we are using Cucumberish as a pod. When we tried to parse our Features directory, the library stated to look for files in the `[NSBundle bundleForClass:[Cucumberish class]]` bundle. However, when using CocoaPods, the library lives in its own module. Because of this, there were no tests running at all. By adding an explicit bundle parameter to the call, you can specify in what bundle the library has to look for the features. 

We kept the existing interface to ensure backward compatibility. However, we added a deprecation flag to be able to remove it in the future for consistency reasons. 