### PR TITLE
Report failure in beforeStartHook

### DIFF
--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -521,7 +521,6 @@ void executeScenario(XCTestCase * self, SEL _cmd, CCIScenarioDefinition * scenar
         [[Cucumberish instance] executeAroundHocksWithScenario:scenario executionBlock:^{
            executeSteps(self, scenario.steps, scenario, filePathPrefix);
         }];
-        [Cucumberish instance].scenariosRun++;
         [[Cucumberish instance] executeAfterHocksWithScenario:scenario];
     }
     @catch (CCIExeption *exception) {
@@ -531,6 +530,7 @@ void executeScenario(XCTestCase * self, SEL _cmd, CCIScenarioDefinition * scenar
         scenario.success = NO;
         scenario.failureReason = exception.reason;
     }
+    [Cucumberish instance].scenariosRun++;
 
     if([Cucumberish instance].scenariosRun == [Cucumberish instance].scenarioCount && [Cucumberish instance].afterFinishHock){
         [Cucumberish instance].afterFinishHock();


### PR DESCRIPTION
Currently an assertion failure in any of the hooks will throw an exception and not report a test failure. This change makes them all report test failures (except after finish, which I'll speak to).

Of importance is that if the beforeStartHook fails it will fail all of the scenarios. This is useful since you will normally setup preconditions needed for the rest of your tests in that hook.

The afterFinishHook is not handled the same way, for a couple reasons:
- It's after all of your scenarios, so if they all passed we don't want a test failure
- I don't know what to do if you have a failure there. Not crashing would probably be nice. I don't use this feature though, so I'm not the best one to ask

