### PR TITLE
Changing order of scenarioCount to increase before call to invoke

### DIFF
--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -394,11 +394,10 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
         //Loop on the example bod(y|ies)
         NSUInteger numberOfIndexes = [(NSArray *)example.exampleData[example.exampleData.allKeys.firstObject] count];
         for(int index = 0; index < numberOfIndexes; index++){
-            
+            [Cucumberish instance].scenarioCount++;
             NSInvocation * inv = [self invocationForScenarioOutline:outline exampleIndex:index  feature:feature featureClass:featureClass];
             
             [invocations addObject:inv];
-            [Cucumberish instance].scenarioCount++;
         }
     }
     
@@ -463,6 +462,7 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
     for(CCIScenarioDefinition * s in feature.scenarioDefinitions){
         NSString * scenarioName = NSStringFromSelector(selector);
         if ([s.name isEqualToString:scenarioName]){
+            [Cucumberish instance].scenarioCount++;
             NSInvocation * inv = [Cucumberish invocationForScenario:s feature:feature featureClass:[self class]];
             invocationTest =  [[self alloc] initWithInvocation:inv];
             break;
@@ -522,8 +522,8 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
                 feature.background = (CCIBackground *)scenario;
                 continue;
             }
-            [invocations addObject:[Cucumberish invocationForScenario:scenario feature:feature featureClass:self]];
             [Cucumberish instance].scenarioCount++;
+            [invocations addObject:[Cucumberish invocationForScenario:scenario feature:feature featureClass:self]];
         }
         
     }
@@ -532,8 +532,8 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
     if([Cucumberish instance].fixMissingLastScenario && feature == lastFeature){
         CCIScenarioDefinition * cleanupScenario = [[CCIScenarioDefinition alloc] init];
         cleanupScenario.name = @"cucumberishCleanupScenario";
-        [invocations addObject:[Cucumberish invocationForScenario:cleanupScenario feature:lastFeature featureClass:self]];
         [Cucumberish instance].scenarioCount++;
+        [invocations addObject:[Cucumberish invocationForScenario:cleanupScenario feature:lastFeature featureClass:self]];
     }
     
     


### PR DESCRIPTION
The call to generate a JSON output file of test results was not called b/c the scenarioCount wasn't being incremented until after this function call resulting in the output file never being written.