### PR TITLE
Issue #50 json output scenario outline type

### DIFF
--- a/Cucumberish/Core/Models/CCIJSONDumper.m
+++ b/Cucumberish/Core/Models/CCIJSONDumper.m
@@ -8,9 +8,8 @@
 
 #import "CCIJSONDumper.h"
 #import "CCIFeature.h"
-#if TARGET_OS_OSX
 
-#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
 #import <UIKit/UIKit.h>
 #endif
 

--- a/Cucumberish/Core/Models/CCIJSONDumper.m
+++ b/Cucumberish/Core/Models/CCIJSONDumper.m
@@ -8,7 +8,12 @@
 
 #import "CCIJSONDumper.h"
 #import "CCIFeature.h"
-//#import <UIKit/UIKit.h>
+#if TARGET_OS_OSX
+
+#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#import <UIKit/UIKit.h>
+#endif
+
 @import Darwin;
 @implementation CCIJSONDumper
 + (instancetype)instance {
@@ -21,6 +26,16 @@
     return instance;
 }
 
++(NSString*)testEnv
+{
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+    return [[UIDevice currentDevice] systemVersion];
+#elif TARGET_OS_OSX
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    return ([NSString stringWithFormat:@"%ld.%ld.%ld", version.majorVersion, version.minorVersion, version.patchVersion]);
+#endif
+    
+}
 +(NSData*)buildJSONOutputData:(NSArray<CCIFeature *> *)features
 {
     NSArray*rawOutput = [self convertMultipleFeaturesToJSONDictionary:features];
@@ -393,10 +408,11 @@
                                               stringByAppendingString:[NSString stringWithFormat:@";%@",[scenario.name.lowercaseString
                                                                                                          stringByReplacingOccurrencesOfString:@" "
                                                                                                          withString:@"-"]]]}];
-    
+
     [retVal addEntriesFromDictionary:@{@"type": [scenario.keyword.lowercaseString stringByReplacingOccurrencesOfString:@" " withString:@"_"]}];
+    
     [retVal addEntriesFromDictionary:[self convertTagsToOutputDictionaryFromScenario:scenario]];
-//    [retVal addEntriesFromDictionary:@{@"test_env":[[UIDevice currentDevice] systemVersion]}];
+    [retVal addEntriesFromDictionary:@{@"test_env":[self testEnv]}];
     
     
     [retVal addEntriesFromDictionary:[self convertStepsToOutputDictionary:scenario]];
@@ -464,7 +480,9 @@
     NSMutableArray* retVal = [NSMutableArray array];
     for (CCIScenarioDefinition* scenario in scenarios)
     {
-        [retVal addObject:[self convertScenarioToJSONDictionary:scenario inFeature: (CCIFeature*)feature]];
+        NSMutableDictionary * jsonDict =[[self convertScenarioToJSONDictionary:scenario inFeature: (CCIFeature*)feature] mutableCopy];
+        jsonDict[@"type"] = @"scenario";
+        [retVal addObject:jsonDict];
     }
     
     return retVal;

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
@@ -13,7 +13,9 @@
 #import "CCIFeature.h"
 #import "NSArray+Hashes.h"
 #import "CCIJSONDumper.h"
-
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#import <UIKit/UIKit.h>
+#endif
 @interface CucumberFeatureSteps()
 
 @property (nonatomic,strong) NSMutableDictionary* savedValues;
@@ -38,6 +40,16 @@
     return self;
 }
 
++(NSString*)testEnv
+{
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+    return [[UIDevice currentDevice] systemVersion];
+#elif TARGET_OS_OSX
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    return ([NSString stringWithFormat:@"%ld.%ld.%ld", version.majorVersion, version.minorVersion, version.patchVersion]);
+#endif
+    
+}
 -(void)setup
 {
     Given(@"a (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
@@ -213,7 +225,8 @@
                                                                   @"type" : @"scenario",
                                                                   @"line" : @12,
                                                                   @"name" : @"Json Output",
-                                                                  @"description" : @""
+                                                                  @"description" : @"",
+                                                                  @"test_env":[[self class] testEnv]
                                                                   }
                                                               ],
                                                       @"name" : @"JSON Output",


### PR DESCRIPTION
This branch addresses Issue #50 and changes the JSON Output to such that scenario outlines now have a type of “scenario”.

This branch also fixes the JSON Output to use a platform intelligent test_env rather than depending on strictly UIKit.