### PR TITLE
Fixed step search range

### DIFF
--- a/Cucumberish/Core/Managers/CCIStepsManager.m
+++ b/Cucumberish/Core/Managers/CCIStepsManager.m
@@ -109,7 +109,7 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
             //Only return nil if we reached the last definition without finding a match
             break;
         }
-        NSRange searchRange = NSMakeRange(0, [step.text lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
+        NSRange searchRange = NSMakeRange(0, [step.text length]);
         NSTextCheckingResult * match = [[regex matchesInString:step.text options:NSMatchingReportCompletion range:searchRange] firstObject];
         
         if (match.numberOfRanges > 1) {


### PR DESCRIPTION
Fixed step search range for steps that include characters like "÷" so the NSRegularExpression does not fail with NSRangeException. The original code gives a range out of the step string length as characters like "÷" counts with more bytes.