### PR TITLE
41: Added contextual and handling

### DIFF
--- a/Cucumberish/Core/CCIBlockDefinitions.h
+++ b/Cucumberish/Core/CCIBlockDefinitions.h
@@ -123,10 +123,11 @@ OBJC_EXTERN void Then(NSString * definitionString, CCIStepBody body);
  
  @Note
  Step definitions are checked in a "Last In First Out" order. If it happens that there are more than one definition matches a step, the last registered definition will be used.
- 
+
  @param definitionString the regular expression that will checked against each Given step line.
  @param body the code block that will be executed if match is occured.
  */
+__attribute__((deprecated("And is deprecated. Implement Given, When, Then or But instead")))
 OBJC_EXTERN void And(NSString * definitionString, CCIStepBody body);
 
 /**

--- a/Cucumberish/Core/Managers/CCIStepsManager.m
+++ b/Cucumberish/Core/Managers/CCIStepsManager.m
@@ -224,7 +224,6 @@ void MatchAll(NSString * definitionString, CCIStepBody body)
 {
     When(definitionString, body);
     Then(definitionString, body);
-    And(definitionString, body);
     But(definitionString, body);
 }
 

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
@@ -40,23 +40,19 @@
 
 -(void)setup
 {
-    Given(@"a (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Given(@"a(n)? (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         
     });
     
-    And(@"an (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    When(@"a(n)? (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         
     });
     
-    When(@"a (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    But(@"a(n)? (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         
     });
     
-    But(@"a (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
-        
-    });
-    
-    Then(@"a (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"a(n)? (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         
     });
     
@@ -245,14 +241,14 @@
         }
     });
     
-    And(@"([A-Za-z0-9]+) value ([A-Za-z0-9]+) has been passed through", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"([A-Za-z0-9]+) value ([A-Za-z0-9]+) has been passed through", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         CCIAssert(self.savedValues[args[0]] != nil, @"Expected to have a saved key of @",args[0]);
         if (self.savedValues[args[0]]) {
             CCIAssert([self.savedValues[args[0]] isEqualToString:args[1]] != NO, @"Expected %@ to equal %@, got %@",args[0],args[1],self.savedValues[args[0]]);
         }
     });
     
-    Match(@[@"Given",@"And"],@"^a step(?: has an optional match \"([a-z]+)\")?$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Given(@"^a step(?: has an optional match \"([a-z]+)\")?$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         if (args.count == 0) {
             [self.savedAStepValues addObject:[NSNull null]];
         } else {
@@ -260,7 +256,7 @@
         }
     });
     
-    Match(@[@"Then",@"And"],@"the step \"a step\" had no match for the optional parameter", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"the step \"a step\" had no match for the optional parameter", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         __block BOOL found = NO;
         for (id obj in self.savedAStepValues) {
             if ([obj isKindOfClass:[NSNull class]]) {
@@ -270,7 +266,7 @@
         CCIAssert(found, @"Expected to find a NSNull, found @%",self.savedAStepValues);
     });
     
-    Match(@[@"Then",@"And"],@"the step \"a step\" had \"([a-z]+)\" matched for the optional parameter", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"the step \"a step\" had \"([a-z]+)\" matched for the optional parameter", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         __block BOOL found = NO;
         for (id obj in self.savedAStepValues) {
             if ([obj isKindOfClass:[NSString class]] && [obj isEqualToString:args[0]]) {
@@ -284,7 +280,7 @@
         self.exactMatchTriggered = YES;
     });
     
-    And(@"a step that just matches strings", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Given(@"a step that just matches strings", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.inexactMatchTriggered = YES;
     });
     
@@ -293,7 +289,7 @@
         CCIAssert(self.exactMatchTriggered, @"Expected the exact match to be triggered");
     });
     
-    And(@"the inexact match passed", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"the inexact match passed", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         CCIAssert(self.inexactMatchTriggered, @"Expected the inexact match to be triggered");
     });
     


### PR DESCRIPTION
This PR brings contextual And handling as suggested in #41 

Given a scenario with the following steps
```
Given a given state
And another given state
```
The second step `another given state` can be defined the following ways

```
Given(@"another given state", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {});
And(@"another given state", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {});
```