### PR TITLE
68: Support for dry-run to print undefined steps

### DIFF
--- a/Cucumberish.podspec
+++ b/Cucumberish.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
     'Cucumberish/Cucumberish.h',
     'Cucumberish/Core/Managers/CCIStepsManager.h',
     'Cucumberish/Core/CCIBlockDefinitions.h',
+    'Cucumberish/Core/CCILogManager.h',
     'Cucumberish/Core/Models/CCIScenarioDefinition.h',
     'Cucumberish/Core/Models/CCIExample.h',
     'Cucumberish/Core/Models/CCIStep.h',

--- a/Cucumberish/Core/Managers/CCILoggingManager.h
+++ b/Cucumberish/Core/Managers/CCILoggingManager.h
@@ -1,0 +1,27 @@
+//
+//  CCILoggingManager.h
+//  CucumberishLibrary
+//
+//  Created by Titouan van Belle on 15.07.17.
+//  Copyright © 2017 Ahmed Ali. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+void CCILog(NSString *format, ...);
+
+
+@protocol CCILogger<NSObject>
+
+- (void)logFormat:(NSString *)format arguments:(va_list)arguments;
+
+@end
+
+
+@interface CCILoggingManager : NSObject
+
++ (CCILoggingManager *)sharedInstance;
+- (void)addLogger:(id<CCILogger>)logger;
+- (void)logFormat:(NSString *)format arguments:(va_list)arguments;
+
+@end

--- a/Cucumberish/Core/Managers/CCILoggingManager.m
+++ b/Cucumberish/Core/Managers/CCILoggingManager.m
@@ -1,0 +1,78 @@
+//
+//  CCILoggingManager.h
+//  CucumberishLibrary
+//
+//  Created by Titouan van Belle on 15.07.17.
+//  Copyright © 2017 Ahmed Ali. All rights reserved.
+//
+
+#import "CCILoggingManager.h"
+
+void CCILog(NSString *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    [[CCILoggingManager sharedInstance] logFormat:format arguments:args];
+    va_end(args);
+}
+
+
+@interface CCIConsoleLogger : NSObject<CCILogger>
+
+@end
+
+@implementation CCIConsoleLogger
+
+- (void)logFormat:(NSString *)format arguments:(va_list)arguments
+{
+    NSLogv(format, arguments);
+}
+
+@end
+
+
+
+@interface CCILoggingManager ()
+
+@property (nonatomic, strong) NSSet<CCILogger> *loggers;
+
+@end
+
+@implementation CCILoggingManager
+
++ (CCILoggingManager *)sharedInstance
+{
+    static CCILoggingManager *sharedInstance;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[CCILoggingManager alloc] init];
+        sharedInstance.loggers = (NSSet<CCILogger> *)[NSSet new];
+        id<CCILogger> consoleLogger = [[CCIConsoleLogger alloc] init];
+        [sharedInstance addLogger:consoleLogger];
+    });
+
+    return sharedInstance;
+}
+
+- (void)addLogger:(id<CCILogger>)logger
+{
+    NSMutableSet *mutableLoggers = [self.loggers mutableCopy];
+    [mutableLoggers addObject:logger];
+    self.loggers = [mutableLoggers copy];
+}
+
+- (void)logFormat:(NSString *)format arguments:(va_list)arguments
+{
+    NSSet *loggers = [self.loggers copy];
+    for (id<CCILogger> logger in loggers) {
+        va_list args_copy;
+        va_copy(args_copy, arguments);
+
+        [logger logFormat:format arguments:args_copy];
+        va_end(args_copy);
+    };
+}
+
+
+@end

--- a/Cucumberish/Core/Managers/CCIStepsManager.h
+++ b/Cucumberish/Core/Managers/CCIStepsManager.h
@@ -36,6 +36,11 @@
 @interface CCIStepsManager : NSObject
 
 /**
+ A set containing all the steps that are not defined when dry run is enabled
+ */
+@property (nonatomic, strong) NSMutableSet<CCIStep *> *undefinedSteps;
+
+/**
  Returns the singleton class of CCIStepsManager
  */
 + (instancetype)instance;
@@ -47,5 +52,7 @@
  @param testCase the test case that is being executed when this step implementation is being called
  */
 - (void)executeStep:(CCIStep *)step inTestCase:(id)testCase;
+
+- (BOOL)executeStepInDryRun:(CCIStep *)step inTestCase:(id)testCase;
 
 @end

--- a/Cucumberish/Core/Managers/CCIStepsManager.m
+++ b/Cucumberish/Core/Managers/CCIStepsManager.m
@@ -37,13 +37,13 @@ const NSString * kDocStringKey = @"DocString";
 const NSString * kXCTestCaseKey = @"XCTestCase";
 
 @interface CCIStepsManager()
+
 @property NSMutableDictionary * definitions;
 @property (copy) NSString *currentContextKeyword;
+
 @end
 
 @implementation CCIStepsManager
-
-
 
 + (instancetype)instance {
     
@@ -60,6 +60,7 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
     self = [super init];
    
     self.definitions = [NSMutableDictionary dictionary];
+    self.undefinedSteps = [NSMutableSet new];
     
     return self;
 }
@@ -76,7 +77,6 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
     return cluster;
 }
 
-
 - (CCIStepDefinition *)findMatchDefinitionForStep:(CCIStep *)step inTestCase:(id)testCase
 {
     if(step.keyword == nil){
@@ -88,14 +88,19 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
         return [self findDefinitionForStep:step amongDefinitions:allDefinitions inTestCase:testCase];
     }
 
+    return [self findDefinitionForStep:step amongDefinitions:[self definitionGroupForStep:step] inTestCase:testCase];
+}
+
+- (NSArray *)definitionGroupForStep:(CCIStep *)step
+{
     NSArray *definitionGroup = self.definitions[step.keyword] ?: @[];
     if ([step.keyword isEqualToString:@"And"]) {
+        step.contextualKeyword = self.currentContextKeyword;
         NSArray *contextDefinitionGroup = self.definitions[self.currentContextKeyword];
         definitionGroup = [definitionGroup arrayByAddingObjectsFromArray:contextDefinitionGroup];
     }
 
-    return [self findDefinitionForStep:step amongDefinitions:definitionGroup inTestCase:testCase];
-
+    return definitionGroup;
 }
 
 - (CCIStepDefinition *)findDefinitionForStep:(CCIStep *)step amongDefinitions:(NSArray *)definitions inTestCase:(id)testCase
@@ -158,6 +163,16 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
     return retDefinition;
 }
 
+- (BOOL)executeStepInDryRun:(CCIStep *)step inTestCase:(id)testCase
+{
+    if (![step.keyword isEqualToString:@"And"]) {
+        self.currentContextKeyword = step.keyword;
+    }
+
+    return [self findMatchDefinitionForStep:step inTestCase:testCase] != nil;
+}
+
+
 - (void)executeStep:(CCIStep *)step inTestCase:(id)testCase
 {
     if (step.keyword && ![step.keyword isEqualToString:@"And"]) {
@@ -173,6 +188,7 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
         errorMessage = [NSString stringWithFormat:@"The implementation of this step, calls another step that is not implemented: %@", [step.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
     }
     CCIAssert(implementation != nil, errorMessage);
+
     if(step.keyword.length > 0){
         NSLog(@"Currently executing: \"%@ %@\"", step.keyword, step.text);
     }

--- a/Cucumberish/Core/Models/CCIScenarioDefinition.h
+++ b/Cucumberish/Core/Models/CCIScenarioDefinition.h
@@ -78,7 +78,6 @@ extern const NSString * kBackgroundKeyword;
  */
 @property (nonatomic, copy) NSString * type;
 
-
 /**
  In case the execution of this scenario is failed, this property will have the failure message
  */

--- a/Cucumberish/Core/Models/CCIStep.h
+++ b/Cucumberish/Core/Models/CCIStep.h
@@ -47,6 +47,11 @@ typedef NS_ENUM(NSInteger,CCIStepStatus) {
 @property (nonatomic, strong) CCIArgument * argument;
 
 /**
+ Set to the keyword of the previous step when the keyword for this step is And
+ */
+@property (nonatomic, copy) NSString * contextualKeyword;
+
+/**
  Can be  When, Then, Given, etc...
  */
 @property (nonatomic, copy) NSString * keyword;
@@ -82,4 +87,9 @@ typedef NS_ENUM(NSInteger,CCIStepStatus) {
  @return the created dictionary
  */
 -(NSDictionary *)toDictionary;
+
+/**
+ @return a string composed of the keyword and the text of the step
+ */
+- (NSString *)fullName;
 @end

--- a/Cucumberish/Core/Models/CCIStep.m
+++ b/Cucumberish/Core/Models/CCIStep.m
@@ -85,6 +85,11 @@
 
 }
 
+- (NSString *)fullName
+{
+    return [NSString stringWithFormat:@"%@ %@", self.contextualKeyword ?: self.keyword, self.text];
+}
+
 
 - (NSString *)description
 {

--- a/Cucumberish/Cucumberish.h
+++ b/Cucumberish/Cucumberish.h
@@ -29,6 +29,11 @@
 #import "CCIStepsManager.h"
 #import "CCIBlockDefinitions.h"
 
+typedef NS_ENUM(NSInteger, CCILanguage) {
+    CCILanguageSwift = 0,
+    CCILanguageObjectiveC = 1
+};
+
 /**
  Cucumberish is the main class you will need to parse your feature files and execute them.
  You should not create instances of this class directly, instead you need to use the instance method.
@@ -95,6 +100,17 @@
  If Cucumberish is installed with Carthage, set the value of this property to be SRC_ROOT which is the preprocessor macro you defined in your build settings
  */
 @property (nonatomic, strong) NSString * testTargetSrcRoot;
+
+/**
+ If set to true, Cucumberish will scan all your feature files without actually running them and detect steps that are not yet defined. Before, after and around blocks are not
+ executed when using this feature. Default is false.
+ */
+@property (nonatomic, assign) BOOL dryRun;
+
+/**
+ The language used to write the step definition when using the dryRun feature. Default is set to CCILanguageSwift
+ */
+@property (nonatomic, assign) CCILanguage dryRunLanguage;
 
 /**
  Retuans a singleton instance of Cucumberish

--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -33,6 +33,7 @@
 #import "NSString+Formatter.h"
 #import "CCIStepDefinition.h"
 #import "CCIScenarioDefinition.h"
+#import "CCILoggingManager.h"
 #import "CCIHock.h"
 #import "CCIAroundHock.h"
 
@@ -81,6 +82,8 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
     self.beforeHocks = [NSMutableArray array];
     self.afterHocks = [NSMutableArray array];
     self.aroundHocks = [NSMutableArray array];
+    self.dryRun = NO;
+    self.dryRunLanguage = CCILanguageSwift;
     
 #ifdef SRC_ROOT
     self.testTargetSrcRoot = SRC_ROOT;
@@ -128,11 +131,6 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
 
     return matches;
 }
-
-
-
-
-
 
 + (void)executeFeaturesInDirectory:(NSString *)featuresDirectory fromBundle:(NSBundle *)bundle includeTags:(NSArray *)tags excludeTags:(NSArray *)excludedTags
 {
@@ -548,6 +546,20 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
 
 #pragma mark - C Functions
 
+void executeDryRun(XCTestCase * self, CCIScenarioDefinition * scenario)
+{
+    for (CCIStep *step in scenario.steps) {
+        if (![[CCIStepsManager instance] executeStepInDryRun:step inTestCase:self]) {
+            NSSet *objects = [[CCIStepsManager instance].undefinedSteps objectsPassingTest:^BOOL(CCIStep * _Nonnull obj, BOOL * _Nonnull stop) {
+                return [step.text isEqualToString:obj.text];
+            }];
+            if (objects.count == 0) {
+                [[CCIStepsManager instance].undefinedSteps addObject:step];
+            }
+        }
+    }
+}
+
 void executeScenario(XCTestCase * self, SEL _cmd, CCIScenarioDefinition * scenario, CCIFeature * feature)
 {
     self.continueAfterFailure = YES;
@@ -597,7 +609,11 @@ void executeScenario(XCTestCase * self, SEL _cmd, CCIScenarioDefinition * scenar
         }
 
         [[Cucumberish instance] executeAroundHocksWithScenario:scenario executionBlock:^{
-           executeSteps(self, scenario.steps, scenario, filePathPrefix);
+            if ([Cucumberish instance].dryRun) {
+                executeDryRun(self, scenario);
+            } else {
+                executeSteps(self, scenario.steps, scenario, filePathPrefix);
+            }
         }];
         [[Cucumberish instance] executeAfterHocksWithScenario:scenario];
     }
@@ -608,10 +624,37 @@ void executeScenario(XCTestCase * self, SEL _cmd, CCIScenarioDefinition * scenar
         scenario.success = NO;
         scenario.failureReason = exception.reason;
     }
+
     [Cucumberish instance].scenariosRun++;
 
-    if([Cucumberish instance].scenariosRun == [Cucumberish instance].scenarioCount){
-        
+    if ([Cucumberish instance].scenariosRun == [Cucumberish instance].scenarioCount) {
+
+        // Print dry run result
+        if ([CCIStepsManager instance].undefinedSteps.count > 0) {
+            NSSortDescriptor *sort = [NSSortDescriptor sortDescriptorWithKey:@"fullName" ascending:YES];
+            NSArray *sortedUndefinedSteps = [[CCIStepsManager instance].undefinedSteps sortedArrayUsingDescriptors:@[sort]];
+
+            NSMutableString *dryRunResult = [@"\n\nDry Run Results" mutableCopy];
+            [dryRunResult appendFormat:@"\n====================================================="];
+
+            [dryRunResult appendFormat:@"\nFound the following undefined steps:\n\n"];
+            for (CCIStep *step in sortedUndefinedSteps) {
+                if ([Cucumberish instance].dryRunLanguage == CCILanguageSwift) {
+                    NSString *keyword = step.keyword;
+                    if ([keyword isEqualToString:@"And"]) {
+                        keyword = step.contextualKeyword;
+                    }
+                    [dryRunResult appendFormat:@"%@(\"^%@$\") { (args, userInfo) in\n\n}\n\n", keyword, step.text];
+                } else if ([Cucumberish instance].dryRunLanguage == CCILanguageObjectiveC) {
+                    [dryRunResult appendFormat:@"%@(@\"^%@$\", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {\n\n});\n\n", step.keyword, step.text];
+                }
+            }
+
+            [dryRunResult appendFormat:@"=====================================================\n\n"];
+
+            CCILog(@"%@", dryRunResult);
+        }
+
         NSString * resultsDir = [Cucumberish instance].resultsDirectory;
         NSString * fileName = [NSString stringWithFormat:@"CucumberishTestResults-%@",targetName];
         
@@ -625,6 +668,7 @@ void executeScenario(XCTestCase * self, SEL _cmd, CCIScenarioDefinition * scenar
                         forFeatures: [[CCIFeaturesManager instance] features]];
 
         }
+
  		if([Cucumberish instance].afterFinishHock){
         	[Cucumberish instance].afterFinishHock();
     	}
@@ -633,7 +677,6 @@ void executeScenario(XCTestCase * self, SEL _cmd, CCIScenarioDefinition * scenar
 
 void executeSteps(XCTestCase * testCase, NSArray * steps, id parentScenario, NSString * filePathPrefix)
 {
-
     for (CCIStep * step in steps) {
 
         @try {

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/CCIDryRunLogger.h
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/CCIDryRunLogger.h
@@ -1,0 +1,18 @@
+//
+//  CCIDryRunLogger.h
+//  CucumberishFeatureDefinition
+//
+//  Created by Titouan van Belle on 15.07.17.
+//  Copyright © 2017 Ahmed Ali. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CCILoggingManager.h"
+
+@interface CCIDryRunLogger : NSObject<CCILogger>
+
++ (CCIDryRunLogger *)sharedInstance;
+
+@property (nonatomic, copy) NSString *logs;
+
+@end

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/CCIDryRunLogger.m
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/CCIDryRunLogger.m
@@ -1,0 +1,39 @@
+//
+//  CCIDryRunLogger.m
+//  CucumberishFeatureDefinition
+//
+//  Created by Titouan van Belle on 15.07.17.
+//  Copyright © 2017 Ahmed Ali. All rights reserved.
+//
+
+#import "CCIDryRunLogger.h"
+
+@implementation CCIDryRunLogger
+
++ (CCIDryRunLogger *)sharedInstance
+{
+    static CCIDryRunLogger *sharedInstance;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[CCIDryRunLogger alloc] init];
+        sharedInstance.logs = @"";
+    });
+
+    return sharedInstance;
+}
+
+- (void)logFormat:(NSString *)format arguments:(va_list)arguments
+{
+    va_list args_copy;
+    va_copy(args_copy, arguments);
+
+    @synchronized(self) {
+        NSString *logMessage = [[NSString alloc] initWithFormat:format arguments:arguments];
+        self.logs = [NSString stringWithFormat:@"%@%@", self.logs, logMessage];
+    }
+
+    va_end(args_copy);
+}
+
+@end

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/1_executes_basic_cucumber.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/1_executes_basic_cucumber.feature
@@ -1,4 +1,4 @@
-Feature: Basic Cucumber
+Feature: 1 Basic Cucumber
 Cucumberish shall execute the basic cucumber steps.
 
 * Given

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/2_fills_examples_into_tables.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/2_fills_examples_into_tables.feature
@@ -1,4 +1,4 @@
-Feature: Fills Examples into Tables
+Feature: 2 Fills Examples into Tables
 Cucumberish shall support filling examples into tables
 
 Scenario Outline: Tables with Examples

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/3_handles_optionals_in_regex.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/3_handles_optionals_in_regex.feature
@@ -1,4 +1,4 @@
-Feature: Optionals In Regex
+Feature: 3 Optionals In Regex
 Cucumberish shall allow optionals in a regex
 
 Scenario: Optionals

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/4_exact_inexact_matches.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/4_exact_inexact_matches.feature
@@ -1,4 +1,4 @@
-Feature: Handle Exact Matches
+Feature: 4 Handle Exact Matches
 Cucumberish shall support matching exact strings, beginning and end
 
 Scenario: Exact and Inexact Matches

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/5_json_output.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/5_json_output.feature
@@ -1,4 +1,4 @@
-Feature: JSON Output
+Feature: 5 JSON Output
 Cucumberish shall output JSON containing details of each feature file.
 
 * Given

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/7_dry_run.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/7_dry_run.feature
@@ -1,0 +1,11 @@
+Feature: 7 Dry Run
+Cucumberish prints in the console the undefined steps
+
+@dry-run
+Scenario: Dry Run - Given
+Given a Given statement which is undefined
+And an And statement which is undefined
+When a When statement which is undefined
+But a But statement which is undefined
+Then a Then statement which is undefined
+Then Cucumberish should print code snippets for these undefined steps in the console

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/dry-run.output
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/dry-run.output
@@ -1,0 +1,26 @@
+
+Dry Run Results
+=====================================================
+Found the following undefined steps:
+
+But("^a But statement which is undefined$") { (args, userInfo) in
+
+}
+
+Given("^a Given statement which is undefined$") { (args, userInfo) in
+
+}
+
+Given("^an And statement which is undefined$") { (args, userInfo) in
+
+}
+
+Then("^a Then statement which is undefined$") { (args, userInfo) in
+
+}
+
+When("^a When statement which is undefined$") { (args, userInfo) in
+
+}
+
+=====================================================

--- a/CucumberishLibraryTest/CucumberishLibrary.xcodeproj/project.pbxproj
+++ b/CucumberishLibraryTest/CucumberishLibrary.xcodeproj/project.pbxproj
@@ -222,6 +222,12 @@
 		C5E80FD51E16BA290042D98D /* NSObject+Dictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = C5E80F731E16BA290042D98D /* NSObject+Dictionary.m */; };
 		C5E80FD61E16BA290042D98D /* NSString+Formatter.m in Sources */ = {isa = PBXBuildFile; fileRef = C5E80F751E16BA290042D98D /* NSString+Formatter.m */; };
 		C5E80FD71E16BA290042D98D /* NSString+Formatter.m in Sources */ = {isa = PBXBuildFile; fileRef = C5E80F751E16BA290042D98D /* NSString+Formatter.m */; };
+		F307B4721F19F90500800005 /* CCILoggingManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F3CBE1A91F19C59700D34E16 /* CCILoggingManager.h */; };
+		F307B4731F19F90C00800005 /* CCILoggingManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F3CBE1AA1F19C59700D34E16 /* CCILoggingManager.m */; };
+		F307B4741F19F90C00800005 /* CCILoggingManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F3CBE1AA1F19C59700D34E16 /* CCILoggingManager.m */; };
+		F307B4751F19F90D00800005 /* CCILoggingManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F3CBE1AA1F19C59700D34E16 /* CCILoggingManager.m */; };
+		F3CBE1AE1F19C9E700D34E16 /* CCIDryRunLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = F3CBE1AD1F19C9E700D34E16 /* CCIDryRunLogger.m */; };
+		F3CBE1B01F19D7D500D34E16 /* dry-run.output in Resources */ = {isa = PBXBuildFile; fileRef = F3CBE1AF1F19D7D500D34E16 /* dry-run.output */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -378,6 +384,11 @@
 		C5E80F731E16BA290042D98D /* NSObject+Dictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+Dictionary.m"; sourceTree = "<group>"; };
 		C5E80F741E16BA290042D98D /* NSString+Formatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Formatter.h"; sourceTree = "<group>"; };
 		C5E80F751E16BA290042D98D /* NSString+Formatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Formatter.m"; sourceTree = "<group>"; };
+		F3CBE1A91F19C59700D34E16 /* CCILoggingManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCILoggingManager.h; sourceTree = "<group>"; };
+		F3CBE1AA1F19C59700D34E16 /* CCILoggingManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CCILoggingManager.m; sourceTree = "<group>"; };
+		F3CBE1AC1F19C9E700D34E16 /* CCIDryRunLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CCIDryRunLogger.h; sourceTree = "<group>"; };
+		F3CBE1AD1F19C9E700D34E16 /* CCIDryRunLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CCIDryRunLogger.m; sourceTree = "<group>"; };
+		F3CBE1AF1F19D7D500D34E16 /* dry-run.output */ = {isa = PBXFileReference; lastKnownFileType = text; path = "dry-run.output"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -446,6 +457,9 @@
 				3E38B0F61DDDE0D600C1CF5A /* CucumberFeatureSteps.m */,
 				3E38B0EC1DDDE0A400C1CF5A /* CucumberishFeatureDefinition.m */,
 				3E38B0EE1DDDE0A400C1CF5A /* Info.plist */,
+				F3CBE1AC1F19C9E700D34E16 /* CCIDryRunLogger.h */,
+				F3CBE1AD1F19C9E700D34E16 /* CCIDryRunLogger.m */,
+				F3CBE1AF1F19D7D500D34E16 /* dry-run.output */,
 			);
 			path = CucumberishFeatureDefinition;
 			sourceTree = "<group>";
@@ -511,6 +525,8 @@
 				C5E80F0A1E16BA280042D98D /* CCIFeaturesManager.m */,
 				C5E80F0B1E16BA280042D98D /* CCIStepsManager.h */,
 				C5E80F0C1E16BA280042D98D /* CCIStepsManager.m */,
+				F3CBE1A91F19C59700D34E16 /* CCILoggingManager.h */,
+				F3CBE1AA1F19C59700D34E16 /* CCILoggingManager.m */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -664,6 +680,7 @@
 				607EEA291E50EE1000F2E8B6 /* CCIFeature.h in Headers */,
 				607EEA2A1E50EE1000F2E8B6 /* CCIHock.h in Headers */,
 				607EEA2B1E50EE1000F2E8B6 /* CCIJSONDumper.h in Headers */,
+				F307B4721F19F90500800005 /* CCILoggingManager.h in Headers */,
 				607EEA2F1E50EE1000F2E8B6 /* CCIStepDefinition.h in Headers */,
 				607EEA311E50EE1000F2E8B6 /* GHAstBuilder.h in Headers */,
 				607EEA321E50EE1000F2E8B6 /* GHAstNode.h in Headers */,
@@ -836,6 +853,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F3CBE1B01F19D7D500D34E16 /* dry-run.output in Resources */,
 				C5E80F9E1E16BA290042D98D /* gherkin-languages.json in Resources */,
 				3E38B10F1DDDE15100C1CF5A /* Features in Resources */,
 			);
@@ -883,6 +901,7 @@
 				C5E80F9A1E16BA290042D98D /* GHDataTable.m in Sources */,
 				C5E80FA41E16BA290042D98D /* GHGherkinDialect.m in Sources */,
 				3E38B0FD1DDDE0D600C1CF5A /* CucumberFeatureSteps.m in Sources */,
+				F307B4731F19F90C00800005 /* CCILoggingManager.m in Sources */,
 				C5E80FC01E16BA290042D98D /* GHStep.m in Sources */,
 				C5E80FBA1E16BA290042D98D /* GHScenario.m in Sources */,
 				C5E80FD01E16BA290042D98D /* NSString+Trim.m in Sources */,
@@ -924,6 +943,7 @@
 				C5E80F961E16BA290042D98D /* GHBackground.m in Sources */,
 				3E38B0ED1DDDE0A400C1CF5A /* CucumberishFeatureDefinition.m in Sources */,
 				C5E80FD41E16BA290042D98D /* NSObject+Dictionary.m in Sources */,
+				F3CBE1AE1F19C9E700D34E16 /* CCIDryRunLogger.m in Sources */,
 				C5E80FA01E16BA290042D98D /* GHExamples.m in Sources */,
 				C5E80F941E16BA290042D98D /* GHAstNode.m in Sources */,
 			);
@@ -965,6 +985,7 @@
 				607EEA0F1E50EDDD00F2E8B6 /* GHNode.m in Sources */,
 				607EEA101E50EDDD00F2E8B6 /* GHParser+Extensions.m in Sources */,
 				607EEA111E50EDDD00F2E8B6 /* GHParser.m in Sources */,
+				F307B4751F19F90D00800005 /* CCILoggingManager.m in Sources */,
 				607EEA121E50EDDD00F2E8B6 /* GHParserException.m in Sources */,
 				607EEA131E50EDDD00F2E8B6 /* GHScenario.m in Sources */,
 				607EEA141E50EDDD00F2E8B6 /* GHScenarioDefinition.m in Sources */,
@@ -1023,6 +1044,7 @@
 				C5E80F951E16BA290042D98D /* GHAstNode.m in Sources */,
 				C5E80FD71E16BA290042D98D /* NSString+Formatter.m in Sources */,
 				C5E80FD31E16BA290042D98D /* NSArray+Hashes.m in Sources */,
+				F307B4741F19F90C00800005 /* CCILoggingManager.m in Sources */,
 				C5E80F811E16BA290042D98D /* CCIExample.m in Sources */,
 				C5E80FA11E16BA290042D98D /* GHExamples.m in Sources */,
 				C5E80FC71E16BA290042D98D /* GHTableRow.m in Sources */,


### PR DESCRIPTION
This pull request allow users to use the dry run feature described in #68 the following way
```
[Cucumberish instance].dryRun = YES;
[Cucumberish instance].dryRunLanguage = CCILanguageObjectiveC;
```

The results are printed in the logs the following way

*dryRunLanguage = CCILanguageObjectiveC*

```
2017-06-16 16:52:22.892 xctest[39431:10863180] 

Dry Run Results
=====================================================
Found the following undefined steps:

Given(@"^a Given statement$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {

});

And(@"^an And statement$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {

});

=====================================================
```

*dryRunLanguage = CCILanguageSwift*

```
2017-06-16 16:52:22.892 xctest[39431:10863180] 

Dry Run Results
=====================================================
Found the following undefined steps:

Given("^a Given statement$") { (args, userInfo) in

}

And("^an And statement$") { (args, userInfo) in

}

=====================================================
```

When all steps are defined, the following is printed

```
Dry Run Results
=====================================================

All the steps are defined

=====================================================
```
