### PR TITLE
Fix contextual And handling

### DIFF
--- a/Cucumberish/Core/Managers/CCIStepsManager.m
+++ b/Cucumberish/Core/Managers/CCIStepsManager.m
@@ -160,7 +160,7 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
 
 - (void)executeStep:(CCIStep *)step inTestCase:(id)testCase
 {
-    if (![step.keyword isEqualToString:@"And"]) {
+    if (step.keyword && ![step.keyword isEqualToString:@"And"]) {
         self.currentContextKeyword = step.keyword;
     }
 

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
@@ -55,6 +55,18 @@
     Given(@"a(n)? (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         
     });
+
+    Given(@"an And statement defined with the keyword Given", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+
+    });
+
+    Given(@"a Given statement using the step method in its implementation", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        step(nil, @"An empty step");
+    });
+
+    Given(@"An empty step", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+
+    });
     
     When(@"a(n)? (.*) statement", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         
@@ -98,6 +110,17 @@
             }
             
         }
+    });
+
+    Then(@"the And statement be defined", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        CCIFeature *feature = [CCIFeaturesManager instance].features.firstObject;
+        CCIScenarioDefinition *mainScenario = feature.scenarioDefinitions.firstObject;
+
+        [mainScenario.steps enumerateObjectsUsingBlock:^(CCIStep * _Nonnull step, NSUInteger idx, BOOL * _Nonnull stop) {
+            if ([step.keyword isEqualToString:@"And"] && step.status != CCIStepStatusPassed) {
+                *stop = YES;
+            }
+        }];
     });
     
     

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/CucumberFeatureSteps.m
@@ -112,7 +112,7 @@
         }
     });
 
-    Then(@"the And statement be defined", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"the And statement should be defined", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         CCIFeature *feature = [CCIFeaturesManager instance].features.firstObject;
         CCIScenarioDefinition *mainScenario = feature.scenarioDefinitions.firstObject;
 

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/6_contextual_and_handling.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/6_contextual_and_handling.feature
@@ -3,10 +3,10 @@ Feature: Contextual And Handling
 Scenario: Contextual And Handling
 Given a Given statement
 And an And statement defined with the keyword Given
-Then the And statement be defined
+Then the And statement should be defined
 
 Scenario: Contextual And Handling using the step() method
 Given a Given statement using the step method in its implementation
 And an And statement defined with the keyword Given
-Then the And statement be defined
+Then the And statement should be defined
 

--- a/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/6_contextual_and_handling.feature
+++ b/CucumberishLibraryTest/CucumberishFeatureDefinition/Features/6_contextual_and_handling.feature
@@ -1,0 +1,12 @@
+Feature: Contextual And Handling
+
+Scenario: Contextual And Handling
+Given a Given statement
+And an And statement defined with the keyword Given
+Then the And statement be defined
+
+Scenario: Contextual And Handling using the step() method
+Given a Given statement using the step method in its implementation
+And an And statement defined with the keyword Given
+Then the And statement be defined
+


### PR DESCRIPTION
I noticed the contextual And handling was not working when steps were using the `step()` method because it would set the `currentContextKeyword` back to nil the keyword is null when using this method.

This PR contains the fix as well as the following new scenarios

```
Feature: Contextual And Handling

Scenario: Contextual And Handling
Given a Given statement
And an And statement defined with the keyword Give
Then the And statement should be defined

Scenario: Contextual And Handling using the step() method
Given a Given statement using the step method in its implementation
And an And statement defined with the keyword Given
Then the And statement should be defined
```

