### PR TITLE
Prevent keyword=(null) in test report

### DIFF
--- a/Cucumberish/Core/Managers/CCIStepsManager.m
+++ b/Cucumberish/Core/Managers/CCIStepsManager.m
@@ -212,7 +212,7 @@ const NSString * kXCTestCaseKey = @"XCTestCase";
             [inv setSelector:aSelector];
             [inv setTarget:xctContextClass];
 
-            NSString *name = [NSString stringWithFormat:@"%@ %@", step.keyword, step.text];
+            NSString *name = [NSString stringWithFormat:@"%@ %@", implementation.type, step.text];
             [inv setArgument:&(name) atIndex:2];
             [inv setArgument:&(activityBlock) atIndex:3];
 


### PR DESCRIPTION
This PR prevent showing (null) as the keyword of a step when the step is executed using the `step` method

