### PR TITLE
Update Cucumberish.m

### DIFF
--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -429,10 +429,10 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
     if(featureClass == nil){
         featureClass = NSClassFromString(className);
         NSUInteger availableClassesWithTheSameName = 1;
-        while (featureClass == nil) {
+        do {
             className = [className stringByAppendingFormat:@"%lu", (long unsigned)availableClassesWithTheSameName];
             featureClass = objc_allocateClassPair([XCTestCase class], [className UTF8String], 0);
-        }
+        } while (featureClass == nil);
     }
     objc_registerClassPair(featureClass);
     return featureClass;


### PR DESCRIPTION
Small change in runtime magic. I've noticed that if the featureClass == nil statement is true, than NSClassFromString will probably return a class. In this case the while loop won't execute and the test will pass w/o any testing done. 

This happens with the example in readme.md