### PR TITLE
JSON report: Adding tags to Scenario Outlines 

### DIFF
--- a/Cucumberish/Core/Models/CCIJSONDumper.m
+++ b/Cucumberish/Core/Models/CCIJSONDumper.m
@@ -345,7 +345,7 @@
     }
     else if ([scenario.tags count] > 0)
     {
-        for(NSString*strTag in scenario.rawTags)
+        for(NSString*strTag in scenario.tags)
         {
             [retVal addObject:[self convertTagToOutputDictionary:strTag]];
         }


### PR DESCRIPTION
Fixing a bug in Cucumberish that leads to Scenario Outlines not having any tags in the JSON output.
It was caused by a faulty line in the JSONDumper that would take the tags from the wrong collection.