### PR TITLE
Resolve individual case runs with non-pretty names

### DIFF
--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -484,7 +484,11 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
 
     for(CCIScenarioDefinition * s in feature.scenarioDefinitions){
         NSString * scenarioName = NSStringFromSelector(selector);
-        if ([s.name isEqualToString:scenarioName]){
+        NSString * comparedName = s.name;
+        if(![[Cucumberish instance] prettyNamesAllowed] && ![[Cucumberish instance] prettyScenarioNamesAllowed]){
+            comparedName = [comparedName camleCaseStringWithFirstUppercaseCharacter:NO];
+        }
+        if ([comparedName isEqualToString:scenarioName]){
             [Cucumberish instance].scenarioCount++;
             NSInvocation * inv = [Cucumberish invocationForScenario:s feature:feature featureClass:[self class]];
             invocationTest =  [[self alloc] initWithInvocation:inv];
@@ -493,6 +497,9 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
           NSRange range = [scenarioName rangeOfCharacterFromSet:[NSCharacterSet decimalDigitCharacterSet] options:NSBackwardsSearch];
             NSInteger exampleIndex = [[scenarioName substringWithRange:range] integerValue] - 1;
             NSString * scenarioOutlineName = [Cucumberish exampleScenarioNameForScenarioName:s.name exampleAtIndex:exampleIndex example:s.examples.firstObject];
+            if(![[Cucumberish instance] prettyNamesAllowed] && ![[Cucumberish instance] prettyScenarioNamesAllowed]){
+                scenarioOutlineName = [scenarioOutlineName camleCaseStringWithFirstUppercaseCharacter:NO];
+            }
             if([scenarioName isEqualToString:scenarioOutlineName]){
                 CCIExample * example = s.examples.firstObject;
                 NSInvocation * inv = [Cucumberish invocationForScenarioOutline:s example:example exampleIndex:exampleIndex feature:feature featureClass:[self class]];


### PR DESCRIPTION
Hi Ahmed,

Thanks for developing this superb library which has become a cornerstone in our automation efforts.

Sorry for the rant, but just quick prologue about this issue:

I noticed that Cucumberish was failing to execute individual test cases in our Test Suite, but we ignored it until we reached a level in automation where we would like to target individual test cases for rerun flaky test purposes. The stakes were high, and we really needed to resolve this or otherwise develop a workaround.

So! Cloning this repo and setting `prettyNames` to false, I noticed the Cucumberish tests exhibited the same issue. (Kudos for dog feeding here, it's such a perfect use case!) Hence, finally, the need to add checks to transform the name to be compared against to match the naming strategy used by the framework.

Please note I couldn't figure out how to add proper tests for the new code, nor find a cleaner approach, so please if you have suggestions, I'm all 👂s.