### PR TITLE
fix: proper layout scenario with spaces

### DIFF
--- a/Cucumberish/Cucumberish.m
+++ b/Cucumberish/Cucumberish.m
@@ -455,6 +455,8 @@ OBJC_EXTERN NSString * stepDefinitionLineForStep(CCIStep * step);
     if(![[Cucumberish instance] prettyNamesAllowed] && ![[Cucumberish instance] prettyScenarioNamesAllowed]){
         methodName = [methodName camleCaseStringWithFirstUppercaseCharacter:NO];
     }
+    
+    methodName = [methodName stringByReplacingOccurrencesOfString:@" " withString:@"_"];
     SEL sel = NSSelectorFromString(methodName);
 
     //Prefered to forward the implementation to a C function instead of Objective-C method, to avoid confusion with the type of "self" object that is being to the implementation


### PR DESCRIPTION
Replace spaces with underscores for more readable layout of scenario name in Terminal.

_It is not common for selectors have spaces in their names. It can be handled at runtime, but log processing tools doesn't expect to find space and result will be truncated_.

> Test Case '-[CCITest testing some scenario]' started.  

Will end up in log like: 
```
CCITest Cucumberish
    ✓ scenario (0.040 seconds)
```

This fix will make it easier to read output:
```
CCITest Cucumberish
    ✓ testing_some_scenario (0.040 seconds)
```